### PR TITLE
Added isodd operator

### DIFF
--- a/core/components/if/snippet.if.php
+++ b/core/components/if/snippet.if.php
@@ -100,6 +100,9 @@ if (isset($subject)) {
             default:
                 $output = (($subject == $operand) ? $then : (isset($else) ? $else : ''));
                 break;
+            case 'isodd':
+                $output = (($subject % 2) ? $then : (isset($else) ? $else : ''));
+            break;
         }
     }
 }


### PR DESCRIPTION
Added an operator that checks if subject is odd or even.
Passes if the subject is an odd integer. 

I needed this for generating empty table cells in getResources' &tplLast: 

``` html
<td>[[+content]]</td>
[[!If? &subject=`[[+total]]` &operator=`isodd` &then=`<td>&nbsp;</td>`]]
```

hope it's useful.
Mika
